### PR TITLE
[FEAT] Checkbox, Agreement 컴포넌트 작성, 테스트

### DIFF
--- a/apps/docs/src/stories/agreement/agreement-item.stories.tsx
+++ b/apps/docs/src/stories/agreement/agreement-item.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { AgreementItem, AgreementItemProps } from '@yaksok/ui/agreement'
+import { useEffect, useState } from 'react'
+
+const meta = {
+  title: 'stories/agreement/agreement-item',
+  component: AgreementItem,
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    Story => (
+      <div className="flex w-[500px] justify-center">
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ['autodocs'],
+  argTypes: {
+    content: {
+      control: {
+        type: 'text',
+      },
+    },
+    isRequired: {
+      control: {
+        type: 'boolean',
+      },
+    },
+    showDetailButton: {
+      control: {
+        type: 'boolean',
+      },
+    },
+  },
+  args: {
+    id: 'personal-info-agreement',
+    content: '개인정보 수집 및 이용약관',
+    isRequired: false,
+    showDetailButton: true,
+    checked: false,
+  },
+} satisfies Meta<typeof AgreementItem>
+export default meta
+
+type Story = StoryObj<typeof AgreementItem>
+
+export const Primary: Story = {
+  render: (props: AgreementItemProps) => {
+    const [checked, setChecked] = useState({
+      [props.id]: props.checked,
+    })
+    useEffect(() => {
+      setChecked({
+        [props.id]: props.checked,
+      })
+    }, [props.checked, props.id])
+
+    return (
+      <AgreementItem
+        {...props}
+        checked={checked[props.id]}
+        setChecked={id => {
+          setChecked({
+            ...checked,
+            [id]: !checked[id],
+          })
+        }}
+      />
+    )
+  },
+  name: 'AgreementItem',
+}

--- a/apps/docs/src/stories/agreement/check-all-button.stories.tsx
+++ b/apps/docs/src/stories/agreement/check-all-button.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { CheckAllButton } from '@yaksok/ui/agreement'
+import { useEffect, useState } from 'react'
+
+const meta = {
+  title: 'stories/agreement/check-all-button',
+  component: CheckAllButton,
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    Story => (
+      <div className="flex w-[500px] justify-center">
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ['autodocs'],
+  argTypes: {
+    checked: {
+      control: {
+        type: 'boolean',
+      },
+    },
+  },
+  args: {
+    checked: false,
+  },
+} satisfies Meta<typeof CheckAllButton>
+export default meta
+
+type Story = StoryObj<typeof CheckAllButton>
+
+export const Primary: Story = {
+  render: props => {
+    const [checked, setChecked] = useState(props.checked)
+
+    useEffect(() => {
+      setChecked(props.checked)
+    }, [props.checked])
+
+    return <CheckAllButton checked={checked} setChecked={setChecked} />
+  },
+  name: 'CheckAllButton',
+}

--- a/apps/docs/src/stories/agreement/index.stories.tsx
+++ b/apps/docs/src/stories/agreement/index.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Agreement } from '@yaksok/ui/agreement'
+
+const meta = {
+  title: 'stories/agreement/index',
+  component: Agreement,
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    Story => (
+      <div className="flex w-[500px] justify-center bg-white p-5">
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ['autodocs'],
+  argTypes: {},
+} satisfies Meta<typeof Agreement>
+export default meta
+
+type Story = StoryObj<typeof Agreement>
+
+export const Primary: Story = {
+  render: () => {
+    const itemList = [
+      { id: 'age', content: '만 14세 이상', isRequired: true },
+      {
+        id: 'personal-info-agreement',
+        content: '개인정보 수집 및 이용약관',
+        showDetailButton: true,
+        isRequired: true,
+      },
+      {
+        id: 'marketing-agreement',
+        content: ' 마케팅 및 이벤트 활용 동의',
+        showDetailButton: true,
+      },
+    ]
+
+    return <Agreement itemList={itemList} />
+  },
+  name: 'Agreement',
+}

--- a/apps/docs/src/stories/checkbox.stories.tsx
+++ b/apps/docs/src/stories/checkbox.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Checkbox, CheckboxProps } from '@yaksok/ui/checkbox'
+import { useEffect, useState } from 'react'
+
+const meta: Meta<CheckboxProps> = {
+  title: 'stories/checkbox',
+  component: Checkbox,
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    Story => (
+      <div className="flex w-[500px] justify-center">
+        <Story />
+      </div>
+    ),
+  ],
+  tags: ['autodocs'],
+  argTypes: {
+    theme: {
+      options: ['default', 'rounded'],
+      control: {
+        type: 'radio',
+      },
+    },
+    value: {
+      control: {
+        type: 'boolean',
+      },
+    },
+  },
+  args: {
+    theme: 'default',
+    checked: false,
+  },
+} satisfies Meta<CheckboxProps>
+export default meta
+
+type Story = StoryObj<typeof Checkbox>
+
+export const Primary: Story = {
+  render: props => {
+    const [value, setValue] = useState(false)
+
+    useEffect(() => {
+      setValue(props.checked ?? false)
+    }, [props.checked])
+
+    return <Checkbox {...props} checked={value} setChecked={setValue} />
+  },
+  name: 'Checkbox',
+}

--- a/packages/icons/src/Check.tsx
+++ b/packages/icons/src/Check.tsx
@@ -2,19 +2,19 @@ import * as React from 'react'
 import type { SVGProps } from 'react'
 const SvgCheck = (props: SVGProps<SVGSVGElement>) => (
   <svg
-    xmlns="http://www.w3.org/2000/svg"
-    width="1em"
-    height="1em"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
     fill="none"
-    viewBox="0 0 15 10"
+    xmlns="http://www.w3.org/2000/svg"
     {...props}
   >
     <path
-      stroke="#000"
+      d="M6 12L10.2426 16.2426L18.727 7.75732"
+      stroke="black"
+      strokeWidth="1.5"
       strokeLinecap="round"
       strokeLinejoin="round"
-      strokeWidth={1.5}
-      d="m1 5 4.243 4.243L13.727.757"
     />
   </svg>
 )

--- a/packages/icons/src/Check.tsx
+++ b/packages/icons/src/Check.tsx
@@ -2,19 +2,19 @@ import * as React from 'react'
 import type { SVGProps } from 'react'
 const SvgCheck = (props: SVGProps<SVGSVGElement>) => (
   <svg
-    width="24"
-    height="24"
-    viewBox="0 0 24 24"
-    fill="none"
     xmlns="http://www.w3.org/2000/svg"
+    width={24}
+    height={24}
+    fill="none"
+    viewBox="0 0 24 24"
     {...props}
   >
     <path
-      d="M6 12L10.2426 16.2426L18.727 7.75732"
-      stroke="black"
-      strokeWidth="1.5"
+      stroke="#000"
       strokeLinecap="round"
       strokeLinejoin="round"
+      strokeWidth={1.5}
+      d="m6 12 4.243 4.243 8.484-8.486"
     />
   </svg>
 )

--- a/packages/icons/svg/check.svg
+++ b/packages/icons/svg/check.svg
@@ -1,3 +1,3 @@
-<svg width="15" height="10" viewBox="0 0 15 10" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M1 5L5.24264 9.24264L13.727 0.757324" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6 12L10.2426 16.2426L18.727 7.75732" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/packages/tailwindcss/src/index.css
+++ b/packages/tailwindcss/src/index.css
@@ -117,6 +117,9 @@
   body {
     @apply bg-bgColor text-foreground;
   }
+  button {
+    @apply cursor-pointer;
+  }
   .clickable {
     @apply transform cursor-pointer transition-transform active:scale-95;
   }
@@ -131,7 +134,7 @@
   --color-gray01: #2c2c2e;
   --color-gray02: #48484a;
   --color-gray03: #636366;
-  --color-gray04: #f4f4f4;
+  --color-gray04: #7b7b7f;
   --color-gray05: #959598;
   --color-gray06: #e3e3e3;
   --color-gray07: #f4f4f4;

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,6 +5,7 @@
   "exports": {
     "./*": "./src/*.tsx",
     "./carousel": "./src/carousel/index.ts",
+    "./agreement": "./src/agreement/index.tsx",
     "./styles.css": "./dist/styles.css"
   },
   "scripts": {

--- a/packages/ui/src/agreement/index.test.tsx
+++ b/packages/ui/src/agreement/index.test.tsx
@@ -1,0 +1,102 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { Agreement } from './index'
+
+const itemList = [
+  { id: 'age', content: '만 14세 이상', isRequired: true },
+  {
+    id: 'personal-info-agreement',
+    content: '개인정보 수집 및 이용약관',
+    showDetailButton: true,
+    isRequired: true,
+  },
+  {
+    id: 'marketing-agreement',
+    content: '마케팅 및 이벤트 활용 동의',
+    showDetailButton: true,
+  },
+]
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('Agreement', () => {
+  it('전체 동의 버튼이 렌더링된다', () => {
+    render(<Agreement itemList={itemList} />)
+    expect(screen.getByText('전체 동의')).toBeInTheDocument()
+  })
+
+  it('각 약관 항목이 필수 여부와 함께 올바르게 렌더링된다', () => {
+    render(<Agreement itemList={itemList} />)
+    itemList.forEach(item => {
+      expect(
+        screen.getByText(
+          content =>
+            content.replace(/\s/g, '') ===
+            `${item.isRequired ? '(필수)' : '(선택)'}${item.content}`.replace(
+              /\s/g,
+              ''
+            )
+        )
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('각 항목 클릭 시 체크박스가 토글된다', () => {
+    render(<Agreement itemList={itemList} />)
+    const ageCheckbox = screen
+      .getByText('(필수) 만 14세 이상')
+      .closest('button')
+      ?.querySelector("input[type='checkbox']")
+    expect(ageCheckbox).not.toBeChecked()
+    fireEvent.click(screen.getByText('(필수) 만 14세 이상').closest('button')!)
+    expect(ageCheckbox).toBeChecked()
+    fireEvent.click(screen.getByText('(필수) 만 14세 이상').closest('button')!)
+    expect(ageCheckbox).not.toBeChecked()
+  })
+
+  it('전체 동의 버튼 클릭 시 기존 선택 항목 상태를 유지하면서 필수 항목들이 체크된다', () => {
+    render(<Agreement itemList={itemList} />)
+    const checkAllButton = screen.getByText('전체 동의').closest('button')!
+    const checkboxes = screen.getAllByRole('checkbox')
+
+    // 마케팅 동의(선택 항목)를 먼저 체크
+    fireEvent.click(
+      screen.getByText('(선택) 마케팅 및 이벤트 활용 동의').closest('button')!
+    )
+    expect(checkboxes[3]).toBeChecked() // 마케팅 동의 체크 확인
+
+    // 전체 동의 버튼 클릭
+    fireEvent.click(checkAllButton)
+
+    // 전체 동의 버튼과 필수 항목들이 체크되었는지 확인
+    expect(checkboxes[0]).toBeChecked() // 전체 동의 버튼
+    expect(checkboxes[1]).toBeChecked() // 만 14세 이상
+    expect(checkboxes[2]).toBeChecked() // 개인정보 수집 및 이용약관
+
+    // 선택 항목(마케팅)은 기존 상태 유지
+    expect(checkboxes[3]).toBeChecked() // 마케팅 동의는 여전히 체크 상태
+  })
+
+  it('전체 동의 버튼 클릭 후 다시 클릭하면 모든 항목이 해제된다', () => {
+    render(<Agreement itemList={itemList} />)
+    const checkAllButton = screen.getByText('전체 동의').closest('button')!
+    const checkboxes = screen.getAllByRole('checkbox')
+    // 전체 동의 클릭(체크) -> 필수 항목들만 체크
+    fireEvent.click(checkAllButton)
+    expect(checkboxes[0]).toBeChecked() // 전체 동의 버튼
+    expect(checkboxes[1]).toBeChecked() // 만 14세 이상
+    expect(checkboxes[2]).toBeChecked() // 개인정보 수집 및 이용약관
+    expect(checkboxes[3]).not.toBeChecked() // 마케팅 및 이벤트 활용 동의
+    // 전체 동의 다시 클릭(해제) -> 모든 항목 해제
+    fireEvent.click(checkAllButton)
+    checkboxes.forEach(cb => expect(cb).not.toBeChecked())
+  })
+
+  it('"보기" 버튼이 필요한 항목에만 렌더링된다', () => {
+    render(<Agreement itemList={itemList} />)
+    const detailButtons = screen.getAllByText('보기')
+    expect(detailButtons.length).toBe(2)
+  })
+})

--- a/packages/ui/src/agreement/index.tsx
+++ b/packages/ui/src/agreement/index.tsx
@@ -86,6 +86,7 @@ function AgreementItem({
   const requirementLabel = isRequired ? '필수' : '선택'
 
   const handleItemClick = () => {
+    console.log('handleItemClick')
     setChecked(id)
   }
 
@@ -95,7 +96,7 @@ function AgreementItem({
         className="clickable flex flex-1 items-center gap-[20px] text-body2"
         onClick={handleItemClick}
       >
-        <Checkbox checked={checked} setChecked={handleItemClick} />
+        <Checkbox checked={checked} />
         <span>{`(${requirementLabel}) ${content}`}</span>
       </button>
       {showDetailButton && (

--- a/packages/ui/src/agreement/index.tsx
+++ b/packages/ui/src/agreement/index.tsx
@@ -1,0 +1,110 @@
+import { Checkbox } from '../checkbox'
+import { useAgreement } from './use-agreement'
+
+export interface AgreementItemContent {
+  id: string
+  content: string
+  isRequired?: boolean
+  showDetailButton?: boolean
+}
+
+export interface AgreementItemProps extends AgreementItemContent {
+  checked: boolean
+  setChecked: (id: string) => void
+}
+
+function CheckAllButton({
+  checked,
+  setChecked,
+}: {
+  checked: boolean
+  setChecked: (prev: boolean) => void
+}) {
+  const handleClick = () => {
+    setChecked(!checked)
+  }
+
+  return (
+    <button
+      className="clickable flex flex-1 items-center gap-[16px] text-body2"
+      onClick={handleClick}
+    >
+      <Checkbox checked={checked} setChecked={handleClick} theme="rounded" />
+      <p className="flex items-center gap-[4px]">
+        <span className="text-subhead1">전체 동의</span>
+        <span className="text-body2 text-gray04">(선택 항목 제외)</span>
+      </p>
+    </button>
+  )
+}
+
+function Agreement({ itemList }: { itemList: AgreementItemContent[] }) {
+  const {
+    itemsChecked,
+    handleCheckItem,
+    handleCheckAll,
+    handleUncheckAll,
+    isAgreementCheckedComplete,
+  } = useAgreement(itemList)
+
+  const handleCheckAllButtonClick = () => {
+    if (isAgreementCheckedComplete) {
+      handleUncheckAll()
+    } else {
+      handleCheckAll()
+    }
+  }
+
+  return (
+    <div className="flex w-full flex-col gap-[32px]">
+      <CheckAllButton
+        checked={isAgreementCheckedComplete}
+        setChecked={handleCheckAllButtonClick}
+      />
+      <ul className="flex flex-col gap-[20px]">
+        {itemList.map(item => (
+          <AgreementItem
+            key={item.id}
+            {...item}
+            checked={itemsChecked[item.id]}
+            setChecked={handleCheckItem}
+          />
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+function AgreementItem({
+  id,
+  content,
+  isRequired,
+  showDetailButton,
+  checked,
+  setChecked,
+}: AgreementItemProps) {
+  const requirementLabel = isRequired ? '필수' : '선택'
+
+  const handleItemClick = () => {
+    setChecked(id)
+  }
+
+  return (
+    <li className="flex w-full list-none flex-row items-center justify-between">
+      <button
+        className="clickable flex flex-1 items-center gap-[20px] text-body2"
+        onClick={handleItemClick}
+      >
+        <Checkbox checked={checked} setChecked={handleItemClick} />
+        <span>{`(${requirementLabel}) ${content}`}</span>
+      </button>
+      {showDetailButton && (
+        <button className="clickable text-body2 text-gray04 underline">
+          보기
+        </button>
+      )}
+    </li>
+  )
+}
+
+export { Agreement, CheckAllButton, AgreementItem }

--- a/packages/ui/src/agreement/index.tsx
+++ b/packages/ui/src/agreement/index.tsx
@@ -62,12 +62,12 @@ function Agreement({ itemList }: { itemList: AgreementItemContent[] }) {
         setChecked={handleCheckAllButtonClick}
       />
       <ul className="flex flex-col gap-[20px]">
-        {itemList.map(item => (
+        {itemList.map(props => (
           <AgreementItem
-            key={item.id}
-            {...item}
-            checked={itemsChecked[item.id]}
+            key={props.id}
+            checked={itemsChecked[props.id]}
             setChecked={handleCheckItem}
+            {...props}
           />
         ))}
       </ul>

--- a/packages/ui/src/agreement/use-agreement.ts
+++ b/packages/ui/src/agreement/use-agreement.ts
@@ -1,0 +1,72 @@
+import { Dispatch, useReducer } from 'react'
+import { AgreementItemContent } from '.'
+
+export const useAgreement = (itemList: AgreementItemContent[]) => {
+  const itemIdList = itemList.map(item => item.id)
+  const defaultItemCheckedState = itemIdList.reduce(
+    (acc, id) => ({ ...acc, [id]: false }),
+    {}
+  )
+
+  type ItemId = (typeof itemIdList)[number]
+
+  type State = Record<ItemId, boolean>
+
+  type Action =
+    | { type: 'CHECK_ITEM'; itemId: ItemId }
+    | { type: 'CHECK_ALL' }
+    | { type: 'UNCHECK_ALL' }
+
+  const reducer = (state: State, action: Action): State => {
+    switch (action.type) {
+      case 'CHECK_ITEM':
+        return { ...state, [action.itemId]: !state[action.itemId] }
+      case 'CHECK_ALL': // 필수 항목들만 모두 체크
+        return Object.keys(state).reduce(
+          (acc, id) => ({
+            ...acc,
+            [id]:
+              itemList.find(item => item.id === id)?.isRequired || state[id],
+          }),
+          {}
+        )
+      case 'UNCHECK_ALL':
+        return Object.keys(state).reduce(
+          (acc, id) => ({ ...acc, [id]: false }),
+          {}
+        )
+      default:
+        return state
+    }
+  }
+
+  const [itemsChecked, dispatch]: [State, Dispatch<Action>] = useReducer(
+    reducer,
+    defaultItemCheckedState
+  )
+
+  const handleCheckItem = (id: ItemId) => {
+    dispatch({ type: 'CHECK_ITEM', itemId: id })
+  }
+
+  const handleCheckAll = () => {
+    dispatch({ type: 'CHECK_ALL' })
+  }
+
+  const handleUncheckAll = () => {
+    dispatch({ type: 'UNCHECK_ALL' })
+  }
+
+  // 모든 필수 항목들의 체크 여부
+  const isAgreementCheckedComplete: boolean = itemList
+    .filter(item => item.isRequired)
+    .every(item => itemsChecked[item.id])
+
+  return {
+    itemsChecked,
+    handleCheckItem,
+    handleCheckAll,
+    handleUncheckAll,
+    isAgreementCheckedComplete,
+  }
+}

--- a/packages/ui/src/checkbox.test.tsx
+++ b/packages/ui/src/checkbox.test.tsx
@@ -1,0 +1,35 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import React from 'react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { Checkbox } from './checkbox'
+
+describe('<Checkbox />', () => {
+  afterEach(() => {
+    cleanup()
+  })
+  it('체크박스가 정상적으로 렌더링된다', () => {
+    render(<Checkbox />)
+    const input = screen.getByRole('checkbox')
+    expect(input).toBeInTheDocument()
+  })
+
+  it('체크박스를 클릭하면 checked 상태가 변경된다', () => {
+    const Wrapper = () => {
+      const [checked, setChecked] = React.useState(false)
+      return <Checkbox checked={checked} setChecked={setChecked} />
+    }
+    render(<Wrapper />)
+    const input = screen.getByRole('checkbox')
+    expect(input).not.toBeChecked()
+    fireEvent.click(input)
+    expect(input).toBeChecked()
+  })
+
+  it('theme prop에 따라 cva에 해당하는 theme의 클래스가 적용된다', () => {
+    const { container } = render(<Checkbox theme="rounded" />)
+    const label = container.querySelector('label')
+    expect(label).toHaveClass(
+      'rounded-full bg-subGray01 has-checked:bg-black01'
+    )
+  })
+})

--- a/packages/ui/src/checkbox.tsx
+++ b/packages/ui/src/checkbox.tsx
@@ -1,0 +1,66 @@
+import { Check } from '@yaksok/icons'
+import { cn } from '@yaksok/utils'
+import { type VariantProps, cva } from 'class-variance-authority'
+import * as React from 'react'
+
+export type CheckboxProps = React.ComponentProps<'input'> &
+  VariantProps<typeof checkboxVariants> & {
+    checked?: boolean
+    setChecked?: (value: boolean) => void
+  }
+
+const checkboxVariants = cva(
+  'group clickable flex items-center justify-center',
+  {
+    variants: {
+      size: {
+        default: 'w-[24px] h-[24px]',
+      },
+
+      theme: {
+        default: '',
+        rounded: 'rounded-full bg-subGray01 has-checked:bg-black01',
+      },
+    },
+    defaultVariants: {
+      theme: 'rounded',
+      size: 'default',
+    },
+  }
+)
+
+const checkVariants = cva('transition-all [&>path]:stroke-[2px]', {
+  variants: {
+    theme: {
+      default:
+        '[&>path]:stroke-subGray01 group-has-[:checked]:[&>path]:stroke-black',
+      rounded: '[&>path]:stroke-white w-[16px] h-[20px]',
+    },
+  },
+  defaultVariants: {
+    theme: 'rounded',
+  },
+})
+
+function Checkbox({
+  className,
+  theme,
+  checked,
+  setChecked,
+  ...props
+}: CheckboxProps) {
+  return (
+    <label className={cn(checkboxVariants({ className, theme }), className)}>
+      <Check className={checkVariants({ theme })} />
+      <input
+        type="checkbox"
+        className="hidden"
+        checked={checked ?? false}
+        onChange={e => setChecked?.(e.target.checked)}
+        {...props}
+      />
+    </label>
+  )
+}
+
+export { Checkbox, checkboxVariants }

--- a/packages/ui/src/checkbox.tsx
+++ b/packages/ui/src/checkbox.tsx
@@ -23,7 +23,7 @@ const checkboxVariants = cva(
       },
     },
     defaultVariants: {
-      theme: 'rounded',
+      theme: 'default',
       size: 'default',
     },
   }
@@ -33,12 +33,12 @@ const checkVariants = cva('transition-all [&>path]:stroke-[2px]', {
   variants: {
     theme: {
       default:
-        '[&>path]:stroke-subGray01 group-has-[:checked]:[&>path]:stroke-black',
+        '[&>path]:stroke-subGray01 group-has-[:checked]:[&>path]:stroke-black w-[20px] h-[20px]',
       rounded: '[&>path]:stroke-white w-[16px] h-[20px]',
     },
   },
   defaultVariants: {
-    theme: 'rounded',
+    theme: 'default',
   },
 })
 

--- a/packages/ui/src/checkbox.tsx
+++ b/packages/ui/src/checkbox.tsx
@@ -50,13 +50,24 @@ function Checkbox({
   ...props
 }: CheckboxProps) {
   return (
-    <label className={cn(checkboxVariants({ className, theme }), className)}>
+    <label
+      className={cn(
+        checkboxVariants({ className, theme }),
+        setChecked || 'pointer-events-none' // setChecked 없으면 부모 이벤트 위임
+      )}
+    >
       <Check className={checkVariants({ theme })} />
       <input
         type="checkbox"
         className="hidden"
         checked={checked ?? false}
-        onChange={e => setChecked?.(e.target.checked)}
+        onChange={e => {
+          if (setChecked) {
+            setChecked?.(e.target.checked)
+          } else {
+            props.onChange?.(e)
+          }
+        }}
         {...props}
       />
     </label>


### PR DESCRIPTION
## ✨ 작업 내용
- [x] 기능 구현 요약
- [x] 테스트 코드 작성
- [ ] 기타 설명 등

## 🧩 관련 이슈
Closes #39 

## 📌 참고 사항
- 동의 항목 '보기' 버튼의 경우, UI가 완성된 후에 이벤트 처리를 구현할 예정입니다.
- 동의 항목 데이터를 서버에 전달하는 상황을 고려하여, 각 항목의 ID를 key로, 동의 여부를 value로 갖는 itemsChecked 객체를 useAgreement 커스텀 훅에서 useReducer로 관리하도록 구현했습니다.
- 동의 항목 버튼('보기' 제외)은 Checkbox와 텍스트로 구성되어 있으며, 체크 이벤트는 버튼에서 처리되도록 구성했습니다. 이벤트 버블링을 고려하여 버튼에서만 클릭 이벤트가 처리되도록 하기 위해, Checkbox에는 setChecked를 명시하지 않았고, label에는 pointer-events-none 클래스를 적용해 Checkbox 자체에서는 클릭 이벤트가 발생하지 않도록 했습니다.




